### PR TITLE
configure to plug laptops to p4-network

### DIFF
--- a/switches/switch-radio.conf
+++ b/switches/switch-radio.conf
@@ -185,12 +185,18 @@ interface TFGigabitEthernet 0/40
  port speed-mode 10G
 !
 interface TFGigabitEthernet 0/41
+ port speed-mode 10G
 !
 interface TFGigabitEthernet 0/42
+ port speed-mode 10G
 !
 interface TFGigabitEthernet 0/43
+ port speed-mode 10G
+ description external-laptop
+ switchport access vlan 100
 !
 interface TFGigabitEthernet 0/44
+ port speed-mode 10G
 !
 interface TFGigabitEthernet 0/45
 !


### PR DESCRIPTION
Updated `switch-radio` configuration such that port 0/43 can be used to connect to the p4-network with a laptop 